### PR TITLE
Update Go version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.2
+          go-version: 1.22
 
       - name: Download dependencies
         run: go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaerubo/kaeruashi
 
-go 1.24.2
+go 1.22
 
 require (
 	github.com/friendsofgo/errors v0.9.2


### PR DESCRIPTION
## Summary
- bump Go version to 1.22
- sync CI go-version with go.mod

## Testing
- `go test ./... -v` *(fails: "Forbidden" when fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_684bc42436e0832f9931f92e5a50e833